### PR TITLE
fix: use only PX4-specifc __PX4 symbol in time.c

### DIFF
--- a/src/c/util/time.c
+++ b/src/c/util/time.c
@@ -10,7 +10,7 @@
 #endif /* ifdef WIN32 */
 
 // PX4
-#if defined(__PX4_NUTTX) || defined(__PX4_POSIX) || defined(UCLIENT_PLATFORM_NUTTX) || defined(UCLIENT_PLATFORM_POSIX)
+#if defined(__PX4)
 
 #ifdef	__cplusplus
 # define __BEGIN_DECLS	extern "C" {
@@ -71,7 +71,7 @@ int64_t uxr_nanos(
     struct timespec ts;
     z_impl_clock_gettime(CLOCK_REALTIME, &ts);
     return (((int64_t)ts.tv_sec) * 1000000000) + ts.tv_nsec;
-#elif defined(__PX4_NUTTX) || defined(__PX4_POSIX) || defined(UCLIENT_PLATFORM_NUTTX) || defined(UCLIENT_PLATFORM_POSIX)
+#elif defined(__PX4)
 
     return (int64_t)(hrt_absolute_time() * 1000);
 #else


### PR DESCRIPTION
The current implementation of the of the logic to use PX4-specific time function:

```cpp
#if defined(__PX4_NUTTX) || defined(__PX4_POSIX) || defined(UCLIENT_PLATFORM_NUTTX) || defined(UCLIENT_PLATFORM_POSIX)
```

ended up always selecting PX4 variation through the `defined(UCLIENT_PLATFORM_NUTTX) || defined(UCLIENT_PLATFORM_POSIX)` checks.

This was spotted in https://github.com/eProsima/Micro-XRCE-DDS-Client/pull/408 and its check: https://github.com/eProsima/Micro-XRCE-DDS-Client/actions/runs/19801939470/job/56760212846 

This PR proposed to change the check to

```cpp
#if defined(__PX4)
```

and then let PX4 uxrce_dds_client module CMakeList.txt to add `__PX4` to the submodule.