### PR TITLE
fix(udp_transport): clean up Windows UDP init failure

### DIFF
--- a/src/c/profile/transport/ip/udp/udp_transport_windows.c
+++ b/src/c/profile/transport/ip/udp/udp_transport_windows.c
@@ -11,6 +11,11 @@ bool uxr_init_udp_platform(
 {
     bool rv = false;
 
+    /* Initialise the platform fd to a sentinel so failure paths are
+     * unambiguous and a later uxr_close_udp_platform() will not try to
+     * closesocket() on an uninitialised handle. */
+    platform->poll_fd.fd = INVALID_SOCKET;
+
     WSADATA wsa_data;
     if (0 != WSAStartup(MAKEWORD(2, 2), &wsa_data))
     {
@@ -59,14 +64,38 @@ bool uxr_init_udp_platform(
             freeaddrinfo(result);
         }
     }
+
+    /* Clean up on failure here so we don't rely on the caller invoking
+     * uxr_close_udp_platform() — the upstream client calls
+     * uxr_init_udp_transport() then immediately discards the transport on
+     * failure, leaking the socket and the WSAStartup() reference. */
+    if (!rv)
+    {
+        if (INVALID_SOCKET != platform->poll_fd.fd)
+        {
+            closesocket(platform->poll_fd.fd);
+            platform->poll_fd.fd = INVALID_SOCKET;
+        }
+        WSACleanup();
+    }
     return rv;
 }
 
 bool uxr_close_udp_platform(
         uxrUDPPlatform* platform)
 {
-    bool rv = (INVALID_SOCKET == platform->poll_fd.fd) ? true : (0 == closesocket(platform->poll_fd.fd));
-    return (0 == WSACleanup()) && rv;
+    bool rv = true;
+    if (INVALID_SOCKET != platform->poll_fd.fd)
+    {
+        rv = (0 == closesocket(platform->poll_fd.fd));
+        platform->poll_fd.fd = INVALID_SOCKET;
+        /* Only decrement the Winsock reference count if we own one — i.e.
+         * the matching uxr_init_udp_platform() succeeded. Without this
+         * guard a close-after-failed-init would underflow Winsock's
+         * process-wide reference count. */
+        rv = (0 == WSACleanup()) && rv;
+    }
+    return rv;
 }
 
 size_t uxr_write_udp_data_platform(


### PR DESCRIPTION
﻿### Solved Problem

Submodule changes required by [PX4/PX4-Autopilot#27297](https://github.com/PX4/PX4-Autopilot/pull/27297) (native Windows SITL with lockstep timing).

The Windows UDP transport had two related issues that surfaced under reconnect storms in native Windows SITL:

1. `uxr_init_udp_platform()` did not initialise `platform->poll_fd.fd`, so a later `uxr_close_udp_platform()` after a failed init could call `closesocket()` on an uninitialised handle.
2. On `uxr_init_udp_platform()` failure the function returned without releasing the socket it had already created or the `WSAStartup()` reference, leaking both. The upstream client discards the transport on init failure rather than calling the matching close, so the leak accumulated over reconnect attempts.
3. `uxr_close_udp_platform()` called `WSACleanup()` unconditionally, which would underflow Winsock''s process-wide reference count when invoked after a failed init.

### Solution

One commit:

- **`fix udp_transport: clean up Windows UDP init failure`** (`f70dc1f`)
  - Initialise `platform->poll_fd.fd` to `INVALID_SOCKET` at the top of `uxr_init_udp_platform()` so failure paths are unambiguous.
  - On init failure, `closesocket()` the fd (if created) and `WSACleanup()` the Winsock reference inside the init function.
  - In `uxr_close_udp_platform()`, only `closesocket()` and `WSACleanup()` when the fd is valid, so a close-after-failed-init is a no-op rather than a Winsock refcount underflow.

Diff is 33 lines in `src/c/profile/transport/ip/udp/udp_transport_windows.c`. POSIX transports are untouched.

### Test coverage

Validated in [PX4/PX4-Autopilot#27297](https://github.com/PX4/PX4-Autopilot/pull/27297) against MicroXRCEAgent on Windows native SITL. Repeated client teardown / reconnect cycles no longer leak Winsock state, and the close-after-failed-init crash path is gone.

### Context

Companion PR: [PX4/PX4-Autopilot#27297](https://github.com/PX4/PX4-Autopilot/pull/27297). Both must be merged together; this submodule update first, then the parent PR''s submodule bump.
